### PR TITLE
Remove unnecessary absolute axis specifier

### DIFF
--- a/src/looper.rs
+++ b/src/looper.rs
@@ -1,6 +1,6 @@
 use pm::types::MidiEvent;
 use pm::OutputPort;
-use ::updatable::Updatable;
+use updatable::Updatable;
 
 #[derive(PartialEq)]
 pub enum State {


### PR DESCRIPTION
Paths in `use` are always absolute, no need to specify that.
