### PR TITLE
Introduce graphics primitives trait and module

### DIFF
--- a/src/graphicsprimitives.rs
+++ b/src/graphicsprimitives.rs
@@ -1,12 +1,12 @@
 use sdl2::render::Renderer;
 use sdl2::rect::Point;
 
-pub trait GraphicsPrimitives {
+pub trait CircleRenderer {
     fn fill_circle(&mut self, cx: i32, cy: i32, r: i32);
     fn draw_circle(&mut self, cx: i32, cy: i32, r: i32);
 }
 
-impl<'a> GraphicsPrimitives for Renderer<'a> {
+impl<'a> CircleRenderer for Renderer<'a> {
     fn fill_circle(&mut self, cx: i32, cy: i32, r: i32) {
         let mut x = r;
         let mut y = 0;

--- a/src/graphicsprimitives.rs
+++ b/src/graphicsprimitives.rs
@@ -1,0 +1,53 @@
+use sdl2::render::Renderer;
+use sdl2::rect::Point;
+
+pub trait GraphicsPrimitives {
+    fn fill_circle(&mut self, cx: i32, cy: i32, r: i32);
+    fn draw_circle(&mut self, cx: i32, cy: i32, r: i32);
+}
+
+impl<'a> GraphicsPrimitives for Renderer<'a> {
+    fn fill_circle(&mut self, cx: i32, cy: i32, r: i32) {
+        let mut x = r;
+        let mut y = 0;
+        let mut err = 0;
+
+        while x >= y {
+            self.draw_line(Point::new(cx + x, cy - y), Point::new(cx + x, cy + y)).unwrap();
+            self.draw_line(Point::new(cx + y, cy - x), Point::new(cx + y, cy + x)).unwrap();
+            self.draw_line(Point::new(cx - y, cy - x), Point::new(cx - y, cy + x)).unwrap();
+            self.draw_line(Point::new(cx - x, cy - y), Point::new(cx - x, cy + y)).unwrap();
+
+            y += 1;
+            err += 1 + 2*y;
+            if 2 * (err - x) + 1 > 0 {
+                x -= 1;
+                err += 1 - 2 * x;
+            }
+        }
+    }
+
+    fn draw_circle(&mut self, cx: i32, cy: i32, r: i32) {
+        let mut x = r;
+        let mut y = 0;
+        let mut err = 0;
+
+        while x >= y {
+            self.draw_point(Point::new(cx + x, cy - y)).unwrap();
+            self.draw_point(Point::new(cx + x, cy + y)).unwrap();
+            self.draw_point(Point::new(cx + y, cy - x)).unwrap();
+            self.draw_point(Point::new(cx + y, cy + x)).unwrap();
+            self.draw_point(Point::new(cx - y, cy - x)).unwrap();
+            self.draw_point(Point::new(cx - y, cy + x)).unwrap();
+            self.draw_point(Point::new(cx - x, cy - y)).unwrap();
+            self.draw_point(Point::new(cx - x, cy + y)).unwrap();
+
+            y += 1;
+            err += 1 + 2*y;
+            if 2 * (err - x) + 1 > 0 {
+                x -= 1;
+                err += 1 - 2 * x;
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,10 +13,12 @@ use sdl2::rect::{Point, Rect};
 mod looper;
 mod updatable;
 mod midi;
+mod graphicsprimitives;
 
 use midi::Note;
 use looper::{Looper, State};
 use updatable::Updatable;
+use graphicsprimitives::GraphicsPrimitives;
 
 macro_rules! colors {
     ($($hex:expr),*) => {
@@ -78,57 +80,6 @@ fn events_to_notes(record_buffer: &[MidiEvent]) -> Vec<Note> {
     }
 
     result
-}
-
-trait GraphicsPrimitives {
-    fn fill_circle(&mut self, cx: i32, cy: i32, r: i32);
-    fn draw_circle(&mut self, cx: i32, cy: i32, r: i32);
-}
-
-impl<'a> GraphicsPrimitives for Renderer<'a> {
-    fn fill_circle(&mut self, cx: i32, cy: i32, r: i32) {
-        let mut x = r;
-        let mut y = 0;
-        let mut err = 0;
-
-        while x >= y {
-            self.draw_line(Point::new(cx + x, cy - y), Point::new(cx + x, cy + y)).unwrap();
-            self.draw_line(Point::new(cx + y, cy - x), Point::new(cx + y, cy + x)).unwrap();
-            self.draw_line(Point::new(cx - y, cy - x), Point::new(cx - y, cy + x)).unwrap();
-            self.draw_line(Point::new(cx - x, cy - y), Point::new(cx - x, cy + y)).unwrap();
-
-            y += 1;
-            err += 1 + 2*y;
-            if 2 * (err - x) + 1 > 0 {
-                x -= 1;
-                err += 1 - 2 * x;
-            }
-        }
-    }
-
-    fn draw_circle(&mut self, cx: i32, cy: i32, r: i32) {
-        let mut x = r;
-        let mut y = 0;
-        let mut err = 0;
-
-        while x >= y {
-            self.draw_point(Point::new(cx + x, cy - y)).unwrap();
-            self.draw_point(Point::new(cx + x, cy + y)).unwrap();
-            self.draw_point(Point::new(cx + y, cy - x)).unwrap();
-            self.draw_point(Point::new(cx + y, cy + x)).unwrap();
-            self.draw_point(Point::new(cx - y, cy - x)).unwrap();
-            self.draw_point(Point::new(cx - y, cy + x)).unwrap();
-            self.draw_point(Point::new(cx - x, cy - y)).unwrap();
-            self.draw_point(Point::new(cx - x, cy + y)).unwrap();
-
-            y += 1;
-            err += 1 + 2*y;
-            if 2 * (err - x) + 1 > 0 {
-                x -= 1;
-                err += 1 - 2 * x;
-            }
-        }
-    }
 }
 
 fn render_note(note: &Note,

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,46 +80,53 @@ fn events_to_notes(record_buffer: &[MidiEvent]) -> Vec<Note> {
     result
 }
 
-fn fill_circle(renderer: &mut Renderer, cx: i32, cy: i32, r: i32) {
-    let mut x = r;
-    let mut y = 0;
-    let mut err = 0;
-
-    while x >= y {
-        renderer.draw_line(Point::new(cx + x, cy - y), Point::new(cx + x, cy + y)).unwrap();
-        renderer.draw_line(Point::new(cx + y, cy - x), Point::new(cx + y, cy + x)).unwrap();
-        renderer.draw_line(Point::new(cx - y, cy - x), Point::new(cx - y, cy + x)).unwrap();
-        renderer.draw_line(Point::new(cx - x, cy - y), Point::new(cx - x, cy + y)).unwrap();
-
-        y += 1;
-        err += 1 + 2*y;
-        if 2 * (err - x) + 1 > 0 {
-            x -= 1;
-            err += 1 - 2 * x;
-        }
-    }
+trait GraphicsPrimitives {
+    fn fill_circle(&mut self, cx: i32, cy: i32, r: i32);
+    fn draw_circle(&mut self, cx: i32, cy: i32, r: i32);
 }
 
-fn draw_circle(renderer: &mut Renderer, cx: i32, cy: i32, r: i32) {
-    let mut x = r;
-    let mut y = 0;
-    let mut err = 0;
+impl<'a> GraphicsPrimitives for Renderer<'a> {
+    fn fill_circle(&mut self, cx: i32, cy: i32, r: i32) {
+        let mut x = r;
+        let mut y = 0;
+        let mut err = 0;
 
-    while x >= y {
-        renderer.draw_point(Point::new(cx + x, cy - y)).unwrap();
-        renderer.draw_point(Point::new(cx + x, cy + y)).unwrap();
-        renderer.draw_point(Point::new(cx + y, cy - x)).unwrap();
-        renderer.draw_point(Point::new(cx + y, cy + x)).unwrap();
-        renderer.draw_point(Point::new(cx - y, cy - x)).unwrap();
-        renderer.draw_point(Point::new(cx - y, cy + x)).unwrap();
-        renderer.draw_point(Point::new(cx - x, cy - y)).unwrap();
-        renderer.draw_point(Point::new(cx - x, cy + y)).unwrap();
+        while x >= y {
+            self.draw_line(Point::new(cx + x, cy - y), Point::new(cx + x, cy + y)).unwrap();
+            self.draw_line(Point::new(cx + y, cy - x), Point::new(cx + y, cy + x)).unwrap();
+            self.draw_line(Point::new(cx - y, cy - x), Point::new(cx - y, cy + x)).unwrap();
+            self.draw_line(Point::new(cx - x, cy - y), Point::new(cx - x, cy + y)).unwrap();
 
-        y += 1;
-        err += 1 + 2*y;
-        if 2 * (err - x) + 1 > 0 {
-            x -= 1;
-            err += 1 - 2 * x;
+            y += 1;
+            err += 1 + 2*y;
+            if 2 * (err - x) + 1 > 0 {
+                x -= 1;
+                err += 1 - 2 * x;
+            }
+        }
+    }
+
+    fn draw_circle(&mut self, cx: i32, cy: i32, r: i32) {
+        let mut x = r;
+        let mut y = 0;
+        let mut err = 0;
+
+        while x >= y {
+            self.draw_point(Point::new(cx + x, cy - y)).unwrap();
+            self.draw_point(Point::new(cx + x, cy + y)).unwrap();
+            self.draw_point(Point::new(cx + y, cy - x)).unwrap();
+            self.draw_point(Point::new(cx + y, cy + x)).unwrap();
+            self.draw_point(Point::new(cx - y, cy - x)).unwrap();
+            self.draw_point(Point::new(cx - y, cy + x)).unwrap();
+            self.draw_point(Point::new(cx - x, cy - y)).unwrap();
+            self.draw_point(Point::new(cx - x, cy + y)).unwrap();
+
+            y += 1;
+            err += 1 + 2*y;
+            if 2 * (err - x) + 1 > 0 {
+                x -= 1;
+                err += 1 - 2 * x;
+            }
         }
     }
 }
@@ -181,9 +188,9 @@ fn render_looper(looper: &Looper,
     renderer.set_draw_color(Color::RGB(255, 0, 0));
 
     if let State::Recording = looper.state {
-        fill_circle(renderer, x, y, r);
+        renderer.fill_circle(x, y, r);
     } else {
-        draw_circle(renderer, x, y, r);
+        renderer.draw_circle(x, y, r);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ mod graphicsprimitives;
 use midi::Note;
 use looper::{Looper, State};
 use updatable::Updatable;
-use graphicsprimitives::GraphicsPrimitives;
+use graphicsprimitives::CircleRenderer;
 
 macro_rules! colors {
     ($($hex:expr),*) => {


### PR DESCRIPTION
### Description

In the scope of #57 we implemented Midpoint circle algorithm to draw a circle primitive. This change extracts all of that to a separate trait and implements that traits for the `Renderer` struct.
