### PR TITLE
Remove redundant replay repeatition

### DIFF
--- a/src/looper.rs
+++ b/src/looper.rs
@@ -80,10 +80,10 @@ impl<'a> Looper<'a> {
             0
         };
 
-        for i in 0..repeat_count {
+        for i in 0..repeat_count - 1 {
             for j in 0..replay_buffer_len {
                 let mut event = self.replay_buffer[j].clone();
-                event.timestamp += i * replay_buffer_duration;
+                event.timestamp += (i + 1) * replay_buffer_duration;
                 self.replay_buffer.push(event);
             }
         }


### PR DESCRIPTION
### Description

The replay buffer was extended by `repeat_count`. But it was not correct because the buffer already contained one sample that had to be repeated. Which leaded to message duplicates with the same timestamp. So to fix that we have to increase the buffer by `repeat_count - 1`.
